### PR TITLE
ci: migrate LizardByte/setup-python-action

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -129,7 +129,7 @@ jobs:
       # 3.3. Установка Python 2.7
       - name: 📥 Шаг 3.3. Установка интерпретатора
         id: setup-python
-        uses: LizardByte/setup-python-action@master
+        uses: LizardByte/actions/actions/setup_python@master
         with:
           # 📌 Примечания:
           #   Устанавливает Python 2.7 только если:


### PR DESCRIPTION
LizardByte/setup-python-action is deprecated and has moved to LizardByte/actions.